### PR TITLE
Minor chat enhancements

### DIFF
--- a/api/src/chat/dialogs/myanmar/disaster-assessment/questions/askAffectedPeopleDialog.ts
+++ b/api/src/chat/dialogs/myanmar/disaster-assessment/questions/askAffectedPeopleDialog.ts
@@ -4,14 +4,14 @@ import { RcdaTypedSession } from "@/chat/utils/rcda-chat-types";
 import RcdaPrompts from "@/chat/prompts/RcdaPrompts";
 import { reviewAffectedPeopleDialog } from "@/chat/dialogs/myanmar/disaster-assessment/review/reviewAffectedPeopleDialog";
 import RcdaChatLocalizer from "@/chat/localization/RcdaChatLocalizer";
-import { MyanmarAffectedPeopleSectionInput } from "@/chat/models/MyanmarConversationData";
+import MyanmarConversationData, { MyanmarAffectedPeopleSectionInput } from "@/chat/models/MyanmarConversationData";
 
 export const askAffectedPeopleDialog = rcdaChatDialog(
     "/askAffectedPeople",
     null,
     [
         ({ session, localizer }) => {
-            RcdaPrompts.adaptiveCardBuilder(session, createAdaptiveCardForAffectedPeople(localizer));
+            RcdaPrompts.adaptiveCard(session, createAdaptiveCardForAffectedPeople(session.conversationData.mm, localizer));
         },
         ({ session, result }) => {
             // save selections
@@ -25,7 +25,7 @@ export const askAffectedPeopleDialog = rcdaChatDialog(
         ]
     });
 
-function createAdaptiveCardForAffectedPeople(localizer: RcdaChatLocalizer) {
+function createAdaptiveCardForAffectedPeople(myanmarData: MyanmarConversationData, localizer: RcdaChatLocalizer) {
     const adaptiveCardBody:Array<object> = [];
 
     const addQuestion = (questionName: keyof MyanmarAffectedPeopleSectionInput, inputLabel: string) => {
@@ -42,7 +42,7 @@ function createAdaptiveCardForAffectedPeople(localizer: RcdaChatLocalizer) {
                 "placeholder": "Quantity",
                 "min": 0,
                 // Check if there is any maximum value for these type of questions. Just confirm. "max": 5,
-                "value": null,
+                "value": myanmarData.people[questionName],
                 "id": questionName
             }
         );

--- a/api/src/chat/dialogs/myanmar/disaster-assessment/review/reviewAffectedPeopleDialog.ts
+++ b/api/src/chat/dialogs/myanmar/disaster-assessment/review/reviewAffectedPeopleDialog.ts
@@ -10,7 +10,7 @@ export const reviewAffectedPeopleDialog: RcdaChatDialog = rcdaChatDialog(
     null,
     [
         ({ session, localizer }) => {
-            RcdaPrompts.adaptiveCardBuilder(session, createAffectedPeopleReviewCard(session, localizer));
+            RcdaPrompts.adaptiveCard(session, createAffectedPeopleReviewCard(session, localizer));
         },
         ({ session, result }) => {
             if (result.response.action === editAction) {

--- a/api/src/chat/dialogs/myanmar/disaster-assessment/review/reviewRankingsDialog.ts
+++ b/api/src/chat/dialogs/myanmar/disaster-assessment/review/reviewRankingsDialog.ts
@@ -10,7 +10,7 @@ export const reviewRankingsDialog: RcdaChatDialog = rcdaChatDialog(
     null,
     [
         ({ session, localizer }) => {
-            RcdaPrompts.adaptiveCardBuilder(session, createRankingsReviewCard(session, localizer));
+            RcdaPrompts.adaptiveCard(session, createRankingsReviewCard(session, localizer));
         },
         ({ session, result }) => {
             const userChoice: string = result.response.id;

--- a/api/src/chat/localization/RcdaTextBurmese.ts
+++ b/api/src/chat/localization/RcdaTextBurmese.ts
@@ -11,8 +11,8 @@ import { MyanmarSectorSeverityScale as SectorSeverityScale } from "@common/model
 import { MyanmarVulnerableGroups as VulnerableGroups } from "@common/models/resources/disaster-assessment/enums/MyanmarVulnerableGroups";
 import { RcdaCommonTextEnglish, RcdaMyanmarTextEnglish } from "@/chat/localization/RcdaTextEnglish";
 
-export class RcdaCommonTextBurmese { //implements RcdaCommonTextEnglish {
-    // This class is for text for common functionality that is not specific to any country, such as welcome dialogues, generic labels, etc.
+// This specifies text for common functionality that is not specific to any country, such as welcome dialogues, generic labels, etc.
+export class RcdaCommonTextBurmese implements RcdaCommonTextEnglish {
     askPreferredLanguage = "Please select a language";
     selectDropdownPlaceholder = "Choose...";
     yes = "Yes";
@@ -20,19 +20,20 @@ export class RcdaCommonTextBurmese { //implements RcdaCommonTextEnglish {
     formatNumber = (value: number) => value.toString();
 }
 
-export class RcdaMyanmarTextBurmese {
+export class RcdaMyanmarTextBurmese implements RcdaMyanmarTextEnglish {
     // intro
     promptUserToSelectChatbotFeature = "What can I assist with?";
     startDisasterAssessmentOption = "Start reporting on a disaster";
     getHelpOption = "Help";
     invalidChoicePromptRetry = "Sorry, I didn't understand that. Please select one of the listed options.";
     choiceNotYetSupportedPromptRetry = "Not yet implemented, please select another option";
-    // report navigation
-    askReportOnAnotherSection = "Would you like to report on anything else?";
-    confirmReportSubmitted = "Thank you, your report has been submitted";
+    // card buttons
     submitCard = "Save";
     acceptReviewCard = "Accept";
     editReviewCard = "Edit";
+    // report navigation
+    askReportOnAnotherSection = "Would you like to report on anything else?";
+    confirmReportSubmitted = "Thank you, your report has been submitted";
     // report info section
     askTownshipName = "What township are you reporting on?";
     askDisasterType = "What is the disaster type?";
@@ -46,7 +47,9 @@ export class RcdaMyanmarTextBurmese {
     // review
     reviewSectionHeader = (sectionName: string) => `Please review **${sectionName}**`;
     reviewSectionNoResponseValue = "No Response";
-    reviewSectorListHeader = "Please confirm that this is the complete list of sectors you can report on";
+    reviewSectorListHeader = "Please confirm the selected **Sectors**";
+    reviewSectorsReported = "You **have** reported on these sectors:";
+    reviewSectorsNotReported = "You **have not** reported on these sectors:";
     // people section
     inputLabelNumberOfPeopleBeforeDisaster = "Number of people before disaster";
     inputLabelNumberOfPeopleLeftArea = "Number of people who have left the area";
@@ -57,7 +60,7 @@ export class RcdaMyanmarTextBurmese {
     inputLabelNumberOfPeopleNotDisplaced = "Number of people affected non-displaced";
     inputLabelNumberOfCasualties = "Number of casualties";
     // sectors section
-    askSectorsToReport = "Which sectors can you report on?";
+    sectorSelectionHeader = "Please select the **Sectors** to report";
     sectorSeverityQuestionHeader = "Severity";
     sectorFactorsQuestionsHeader = "Factors";
     sectorBasicNeedsQuestionHeader = "Basic Needs";
@@ -113,11 +116,11 @@ export class RcdaMyanmarTextBurmese {
         [SectorFactors.Use]: "Use",
     };
     sectorBasicNeedsConcernScale: RcdaEnumLabels<SectorBasicNeedsConcernScale> = {
-        [1]: "I don’t feel worried at all about meeting this need",
-        [2]: "I feel worried but we should be able to cope",
-        [3]: "I feel worried for some or all family members and I’m not sure we will be able to cope",
-        [4]: "I feel worried for the health of some or all family members",
-        [5]: "I feel worried for the life of some or all family members"
+        [1]: "People do not feel worried at all about meeting this need",
+        [2]: "People are worried but think they should be able to cope",
+        [3]: "People are worried about the wellbeing of some or all their family members and not sure they will be able to cope",
+        [4]: "People are worried about the health of some or all their family members",
+        [5]: "People are worried about the life of some or all their family members"
     };
     sectorFactorImpactScale: RcdaEnumLabels<SectorFactorImpactScale> = {
         [0]: "Factor with Zero Impact",

--- a/api/src/chat/localization/RcdaTextEnglish.ts
+++ b/api/src/chat/localization/RcdaTextEnglish.ts
@@ -26,12 +26,13 @@ export class RcdaMyanmarTextEnglish {
     getHelpOption = "Help";
     invalidChoicePromptRetry = "Sorry, I didn't understand that. Please select one of the listed options.";
     choiceNotYetSupportedPromptRetry = "Not yet implemented, please select another option";
-    // report navigation
-    askReportOnAnotherSection = "Would you like to report on anything else?";
-    confirmReportSubmitted = "Thank you, your report has been submitted";
+    // card buttons
     submitCard = "Save";
     acceptReviewCard = "Accept";
     editReviewCard = "Edit";
+    // report navigation
+    askReportOnAnotherSection = "Would you like to report on anything else?";
+    confirmReportSubmitted = "Thank you, your report has been submitted";
     // report info section
     askTownshipName = "What township are you reporting on?";
     askDisasterType = "What is the disaster type?";
@@ -45,7 +46,9 @@ export class RcdaMyanmarTextEnglish {
     // review
     reviewSectionHeader = (sectionName: string) => `Please review **${sectionName}**`;
     reviewSectionNoResponseValue = "No Response";
-    reviewSectorListHeader = "Please confirm that this is the complete list of sectors you can report on";
+    reviewSectorListHeader = "Please confirm the selected **Sectors**";
+    reviewSectorsReported = "You **have** reported on these sectors:";
+    reviewSectorsNotReported = "You **have not** reported on these sectors:";
     // people section
     inputLabelNumberOfPeopleBeforeDisaster = "Number of people before disaster";
     inputLabelNumberOfPeopleLeftArea = "Number of people who have left the area";
@@ -56,7 +59,7 @@ export class RcdaMyanmarTextEnglish {
     inputLabelNumberOfPeopleNotDisplaced = "Number of people affected non-displaced";
     inputLabelNumberOfCasualties = "Number of casualties";
     // sectors section
-    askSectorsToReport = "Which sectors can you report on?";
+    sectorSelectionHeader = "Please select the **Sectors** to report";
     sectorSeverityQuestionHeader = "Severity";
     sectorFactorsQuestionsHeader = "Factors";
     sectorBasicNeedsQuestionHeader = "Basic Needs";
@@ -112,11 +115,11 @@ export class RcdaMyanmarTextEnglish {
         [SectorFactors.Use]: "Use",
     };
     sectorBasicNeedsConcernScale: RcdaEnumLabels<SectorBasicNeedsConcernScale> = {
-        [1]: "I don’t feel worried at all about meeting this need",
-        [2]: "I feel worried but we should be able to cope",
-        [3]: "I feel worried for some or all family members and I’m not sure we will be able to cope",
-        [4]: "I feel worried for the health of some or all family members",
-        [5]: "I feel worried for the life of some or all family members"
+        [1]: "People do not feel worried at all about meeting this need",
+        [2]: "People are worried but think they should be able to cope",
+        [3]: "People are worried about the wellbeing of some or all their family members and not sure they will be able to cope",
+        [4]: "People are worried about the health of some or all their family members",
+        [5]: "People are worried about the life of some or all their family members"
     };
     sectorFactorImpactScale: RcdaEnumLabels<SectorFactorImpactScale> = {
         [0]: "Factor with Zero Impact",

--- a/api/src/chat/localization/botbuilder/en/BotBuilder.json
+++ b/api/src/chat/localization/botbuilder/en/BotBuilder.json
@@ -1,3 +1,4 @@
 {
-    "default_error": "Sorry, something went wrong and we need to start over."
+    "default_error": "Sorry, something went wrong and we need to start over.",
+    "retry_adaptive_card": "Sorry, I didn't understand that. Please use the buttons on the current card."
 }

--- a/api/src/chat/localization/botbuilder/my/BotBuilder.json
+++ b/api/src/chat/localization/botbuilder/my/BotBuilder.json
@@ -1,3 +1,4 @@
 {
-    "default_error": "Sorry, something went wrong and we need to start over."
+    "default_error": "Sorry, something went wrong and we need to start over.",
+    "retry_adaptive_card": "Sorry, I didn't understand that. Please use the buttons on the current card."
 }

--- a/api/src/chat/prompts/RcdaPromptAdaptiveCard.ts
+++ b/api/src/chat/prompts/RcdaPromptAdaptiveCard.ts
@@ -1,9 +1,14 @@
-import { Prompt, IPromptFeatures, IPromptOptions, IPromptContext  } from "botbuilder";
+import { Prompt, IPromptFeatures, IPromptOptions, IPromptContext, Session  } from "botbuilder";
+
+interface RcdaPromptContext<TOptions extends IPromptOptions> extends IPromptContext {
+    options: TOptions;
+}
 
 export class RcdaPromptAdaptiveCard extends Prompt<IPromptFeatures> {
+
     constructor(features?: IPromptFeatures) {
         super({
-            defaultRetryPrompt: "Unable to determine input. Please try again.",
+            defaultRetryPrompt: "retry_adaptive_card",
             defaultRetryNamespace: "BotBuilder"
             // recognizeScore: 1.0
         });
@@ -12,9 +17,12 @@ export class RcdaPromptAdaptiveCard extends Prompt<IPromptFeatures> {
 
         // Default recognizer logic
         this.onRecognize((context, cb) => {
+
             const form = context.message.value;
 
-            if (form && !this.features.disableRecognizer) {
+            const isCurrentCard = form && form.rcdaAdaptiveCardId === context.dialogData.options.rcdaAdaptiveCardId;
+            
+            if (isCurrentCard && !this.features.disableRecognizer) {
                 cb(null, 1.0, form);
             } else {
                 cb(null, 0.0);
@@ -22,7 +30,7 @@ export class RcdaPromptAdaptiveCard extends Prompt<IPromptFeatures> {
         });
 
         this.onFormatMessage((session, text, speak, callback) => {
-            const context = (<IPromptContext>session.dialogData);
+            const context = <RcdaPromptContext<IRcdaPromptAdaptiveCardOptions>>session.dialogData;
             const options = context.options;
             const turnZero = context.turns === 0 || context.isReprompt;
             const message = session.message.text
@@ -45,4 +53,5 @@ export class RcdaPromptAdaptiveCard extends Prompt<IPromptFeatures> {
 
 export interface IRcdaPromptAdaptiveCardOptions extends IPromptOptions {
     //TODO define options? specify whether can be re-submitted? can that be implemented here?
+    rcdaAdaptiveCardId: string;
 }

--- a/api/src/services/ChatPromptReportService.ts
+++ b/api/src/services/ChatPromptReportService.ts
@@ -3,7 +3,7 @@ import UserRepo from "@/repo/UserRepo";
 import ChatPromptRequest, { ChatPromptRequestType } from "@common/models/services/chat-prompt/ChatPromptRequest";
 import RcdaCountries from "@common/system/RcdaCountries";
 import RcdaError, { RcdaErrorTypes } from "@common/system/RcdaError";
-import enumContainsValue from "@common/utils/enumContainsValue";
+import { enumContainsValue } from "@common/utils/enumHelpers";
 
 export default class ChatPromptReportService {
 

--- a/common/src/utils/enumHelpers.ts
+++ b/common/src/utils/enumHelpers.ts
@@ -1,4 +1,4 @@
-export default function enumContainsValue(enumType: any, value: string, caseSensitive = false) {
+export function enumContainsValue(enumType: any, value: string, caseSensitive = false) {
     let enumValues = Object.keys(enumType).map(x => enumType[x]).map(x => caseSensitive ? x : x.toUpperCase());
     let possibleEnumValue = caseSensitive ? value : value.toUpperCase();
 

--- a/common/src/utils/objectHelpers.ts
+++ b/common/src/utils/objectHelpers.ts
@@ -1,0 +1,8 @@
+export function getKeys<T extends {}>(arg: T): (keyof T)[] {
+    return Object.keys(arg) as (keyof T)[];
+}
+
+export function getValues<T extends {}>(arg: T): T[(keyof T)][] {
+    let keys = Object.keys(arg) as (keyof T)[];
+    return keys.map(key => arg[key]);
+}


### PR DESCRIPTION
Does the following:
- When editing a previously completed section, answers are pre-populated
- Change style and navigational placement of review selected sections card
- Set 'Zero Impact' value for Sector factor severity scale to numeric value 0
- Prevent previous adaptive card prompts from being re-submitted
- Fix issue with rankings review
- Replace 'RcdaPrompts.adaptiveCardBuilder' with 'RcdaPrompts.adaptiveCard', deprecate old behavior of the latter in favor of the former